### PR TITLE
Fix compatibility error and max code lines

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -68,6 +68,8 @@ params:
   math:
     enable: true
   page:
+    code:
+      maxShownLines: -1
     lightgallery: true
     share:
       enable: true
@@ -91,7 +93,7 @@ params:
     enable: false
   verification:
     google: VrH7LVgvAmCiD5vBXpJ61NdL4bUlGwGU-ynOhH-VUd8
-  version: 1.2.X
+  version: 1.3.X
 permalinks:
   posts: /posts/:year/:month/:slug/
 theme: uBlogger


### PR DESCRIPTION
I updated the uBlogger theme compatibility version number to 1.3.X. This
was giving an error at build time.

I changed the configuration for the maximum number of code lines to show
before collapsing the code block. I turned off the collapse feature.