### PR TITLE
Enable Disqus comments

### DIFF
--- a/src/themes/normal/layouts/_default/single.html
+++ b/src/themes/normal/layouts/_default/single.html
@@ -7,4 +7,5 @@
 
   {{ .Content }}
   {{ partial "terms.html" (dict "taxonomy" "tags" "page" .) }}
+  {{ template "_internal/disqus.html" . }}
 {{ end }}

--- a/src/web/config/_default/hugo.yaml
+++ b/src/web/config/_default/hugo.yaml
@@ -28,5 +28,8 @@ module:
   imports:
     - path: github.com/mfcollins3/website/src/themes/normal
 newContentEditor: code
+services:
+  disqus:
+    shortname: michaelfcollinsiii
 timeZone: "America/Phoenix"
 title: "Michael F. Collins, III"


### PR DESCRIPTION
I added the website shortname to the configuration file for Disqus. This will enable Disqus comments for the blog posts on the website. I updated the single page template to include the Disqus comments at the end of the page.