### PR TITLE
Integrate Google Analytics

### DIFF
--- a/src/themes/normal/layouts/partials/head.html
+++ b/src/themes/normal/layouts/partials/head.html
@@ -1,4 +1,5 @@
 {{ partialCached "privacy_controls_and_cookie_solution.html" . }}
+{{ template "_internal/google_analytics.html" . }}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width">
 <title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ printf "%s | %s" .Title site.Title }}{{ end }}</title>

--- a/src/web/config/production/hugo.yaml
+++ b/src/web/config/production/hugo.yaml
@@ -19,3 +19,6 @@
 # IN THE SOFTWARE.
 
 baseurl: "https://michaelfcollins3.dev"
+services:
+  googleAnalytics:
+    id: G-NDGMMHLHNR


### PR DESCRIPTION
I integrated Google Analytics to track the website traffic. Google
Analytics will capture information about what pages people are visiting
and what topics they're interested in so that I can adjust my approach
to blogging.